### PR TITLE
Update gemnasium-toolbelt.rb

### DIFF
--- a/gemnasium-toolbelt.rb
+++ b/gemnasium-toolbelt.rb
@@ -29,7 +29,7 @@ class GemnasiumToolbelt < Formula
     to save your Gemnasium credentials.
 
     If you already have a project on Gemnasium, you'll need to run
-      gemnasium configure
+      gemnasium configure <project-name>
 
     If you want to create a new project on Gemnasium, you'll need to run
       gemnasium projects create


### PR DESCRIPTION
add explanation to fill project name on configure command.

```
$ gemnasium configure
[project slug] can't be empty
```
